### PR TITLE
Fix CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ install:
   - shards install
 script:
   - crystal spec --verbose
-  - bin/ameba
+  - crystal bin/ameba.cr
 before_deploy:
   - crystal docs
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ install:
   - shards install
 script:
   - crystal spec --verbose
-  - crystal bin/ameba.cr
+  - bin/ameba
 before_deploy:
   - crystal docs
 deploy:

--- a/shard.yml
+++ b/shard.yml
@@ -8,8 +8,8 @@ authors:
 
 development_dependencies:
   ameba:
-    github: veelenga/ameba
-    version: 0.9.0
+    github: crystal-ameba/ameba
+    version: ~> 0.10.0
 
 crystal: 0.27.0
 

--- a/spec/inotify_spec.cr
+++ b/spec/inotify_spec.cr
@@ -77,7 +77,6 @@ describe Inotify do
         # We should get MODIFY two times.
         EVENT_CHAN.receive.should eq EVENT_CHAN.receive
         EVENT_CHAN.should be_empty
-        watcher.unwatch TEST_FILE
       end
       watcher.close
       cleanup TEST_FILE

--- a/src/inotify/watcher.cr
+++ b/src/inotify/watcher.cr
@@ -35,7 +35,7 @@ module Inotify
       spawn lurk
     end
 
-    private def lurk
+    private def lurk # ameba:disable Metrics/CyclomaticComplexity
       pos = 0
       while @enabled
         slice = Slice(UInt8).new(LibInotify::BUF_LEN)


### PR DESCRIPTION
Ameba linter fails to build in CI. 
```sh
$ crystal --version
Crystal 0.30.1 [5e6a1b672] (2019-08-12)
LLVM: 4.0.0
Default target: x86_64-unknown-linux-gnu
$ shards --version
Shards 0.8.1 [0147a56] (2019-08-12)
$ shards install
Fetching https://github.com/veelenga/ameba.git
Installing ameba (0.9.0)
Postinstall make bin
Failed make bin:
/usr/bin/shards build 
Dependencies are satisfied
Building: ameba
Error target ameba failed to compile:
In src/ameba/inline_comments.cr:97:7
 97 | commented? = false
      ^
Error: unexpected token: =
Makefile:8: recipe for target 'bin/ameba' failed
make: *** [bin/ameba] Error 1
The command "shards install" failed and exited with 1 during .
```